### PR TITLE
Update test script in package.json to run Jest in watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "test": "jest --watchAll",
+    "test": "jest --watch",
     "lint": "expo lint",
     "format": "prettier --write ."
   },


### PR DESCRIPTION
This pull request includes a small but significant change to the `package.json` file. The change modifies the test script to use a different Jest command for running tests.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R11): Changed the `test` script from `jest --watchAll` to `jest --watch`.